### PR TITLE
Upgraded Library versions

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -96,7 +96,7 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "27.0.3"
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         applicationId "com.go_social"
@@ -105,7 +105,7 @@ android {
         versionCode 1
         versionName "1.0"
         ndk {
-            abiFilters "armeabi-v7a", "x86"
+            abiFilters "armeabi-v7a", "arm64-v8a", "x86"
         }
     }
     splits {
@@ -113,7 +113,7 @@ android {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
             universalApk false  // If true, also generate a universal APK
-            include "armeabi-v7a", "x86"
+            include "armeabi-v7a", "arm64-v8a", "x86"
         }
     }
     buildTypes {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
+#Tue Apr 06 13:26:18 IST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-# distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/package.json
+++ b/package.json
@@ -13,15 +13,19 @@
     "react-native": "^0.58.6",
     "react-native-elements": "^1.1.0",
     "react-native-fbsdk": "1.0.0-rc.3",
-    "react-native-gesture-handler": "^1.0.12",
+    "react-native-gesture-handler": "^1.10.3",
     "react-native-google-places-autocomplete": "^1.3.9",
     "react-native-image-crop-picker": "^0.28.0",
     "react-native-image-picker": "^2.0.0",
     "react-native-maps": "^0.26.1",
     "react-native-maps-directions": "^1.6.0",
     "react-native-micro-animated-button": "0.0.28",
+    "react-native-reanimated": "^2.1.0",
+    "react-native-safe-area-context": "^3.2.0",
+    "react-native-screens": "^3.0.0",
     "react-native-vector-icons": "^6.1.0",
-    "react-navigation": "^4.0.6"
+    "react-navigation": "^4.4.4",
+    "react-navigation-stack": "^2.10.4"
   },
   "devDependencies": {
     "babel-jest": "25.1.0",


### PR DESCRIPTION
1) Upgraded buildToolsversion to minimum require for running

2) Added arm64-v8a, as to run the project on android emulator(Apple Macbook Pro M1 chip)

3) Updated classpath to higher version

4) Upgraded react-navigation, react-navigation-stack, react-native-gesture-handler to higher Versions.

Fixes this #124 