### PR TITLE
fixed dependencies issue

### DIFF
--- a/app/screens/ForumScreen/forumScreen.js
+++ b/app/screens/ForumScreen/forumScreen.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { ScrollView, Text, View, TouchableOpacity, Image } from "react-native";
 import HeaderBar from '../../components/HeaderBar/HeaderBar';
 import ForumBox from '../../components/ForumBox/ForumBox';
-import styles from './style';
+import styles from './styles';
 
 
 export default class ForumScreen extends Component {    

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "test": "jest --detectOpenHandles -u"
   },
   "dependencies": {
+    "@hapi/joi": "^17.1.1",
     "email-validator": "^2.0.4",
     "firebase": "^7.2.2",
-    "react": "16.12.0",
-    "react-native": "^0.58.6",
+    "react": "16.8.6",
+    "react-native": "^0.60.0",
     "react-native-elements": "^1.1.0",
     "react-native-fbsdk": "1.0.0-rc.3",
     "react-native-gesture-handler": "^1.0.12",


### PR DESCRIPTION
This PR is with respect to issue #132 

In `package.json` we have to update the version of `react-native` from `0.58.6`  to `0.60.6` otherwise `react-native-fbsdk` throws dependencies issues.

Likewise we have to upgrade the version of `react` from `16.12.0` to `16.8.6` to make `npm install` work.

@shehand Please review it and let me know if any changes are required.