### PR TITLE
Fixed `styles` in `forumScreen.js`

### DIFF
--- a/app/screens/ForumScreen/forumScreen.js
+++ b/app/screens/ForumScreen/forumScreen.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { ScrollView, Text, View, TouchableOpacity, Image } from "react-native";
 import HeaderBar from '../../components/HeaderBar/HeaderBar';
 import ForumBox from '../../components/ForumBox/ForumBox';
-import styles from './style';
+import styles from './styles';
 
 
 export default class ForumScreen extends Component {    

--- a/package.json
+++ b/package.json
@@ -7,11 +7,10 @@
     "test": "jest --detectOpenHandles -u"
   },
   "dependencies": {
-    "@hapi/joi": "^17.1.1",
     "email-validator": "^2.0.4",
     "firebase": "^7.2.2",
-    "react": "16.8.6",
-    "react-native": "^0.60.0",
+    "react": "16.12.0",
+    "react-native": "^0.58.6",
     "react-native-elements": "^1.1.0",
     "react-native-fbsdk": "1.0.0-rc.3",
     "react-native-gesture-handler": "^1.0.12",


### PR DESCRIPTION
`forumScreen.js` was having file linking issues with `./style`, as the original files name is `./styles` due to which it was not able to access `styles`.

This PR is for fixing that issue.