### PR TITLE
fixed import issues in `ForumBox.js`

### DIFF
--- a/app/components/ForumBox/styles.js
+++ b/app/components/ForumBox/styles.js
@@ -1,4 +1,4 @@
-import { StyleSheet, Dimensions } from "react-native";
+import { StyleSheet, Dimensions,Platform } from "react-native";
 
 let deviceWidth = Dimensions.get("window").width;
 let deviceHeight = Dimensions.get("window").height;


### PR DESCRIPTION
we are using `Platform` for finding the platform on which we are running the app but we are not importing the `Platform` package from `react-native` due to which we are getting the below listed error.

![WhatsApp Image 2022-03-23 at 11 51 15 PM](https://user-images.githubusercontent.com/58719389/159771302-19ad53e7-41a8-4f3c-958f-1f177b2fa564.jpeg)

This PR is for fixing that dependency issue.