### PR TITLE
Fixed `object not iterable error `

### DIFF
--- a/app/components/ForumBox/styles.js
+++ b/app/components/ForumBox/styles.js
@@ -1,4 +1,4 @@
-import { StyleSheet, Dimensions } from "react-native";
+import { StyleSheet, Dimensions,Platform } from "react-native";
 
 let deviceWidth = Dimensions.get("window").width;
 let deviceHeight = Dimensions.get("window").height;

--- a/app/components/ForumBox/styles.js
+++ b/app/components/ForumBox/styles.js
@@ -1,4 +1,4 @@
-import { StyleSheet, Dimensions,Platform } from "react-native";
+import { StyleSheet, Dimensions} from "react-native";
 
 let deviceWidth = Dimensions.get("window").width;
 let deviceHeight = Dimensions.get("window").height;

--- a/config/config.example.js
+++ b/config/config.example.js
@@ -7,13 +7,15 @@ var config = {
   projectId: "",
   storageBucket: "",
   messagingSenderId: "",
+  appId: "",
+  measurementId: ""
 };
-!firebase.apps.length ? firebase.initializeApp(config) : firebase.app();
+ !firebase.apps.length ? firebase.initializeApp(config) : firebase.app();
 
-var MAP_API_KEY = "";
+ var MAP_API_KEY = "";
 
-export const f = firebase;
-export const database = firebase.database();
-export const auth = firebase.auth();
-export const storage = firebase.storage();
-export const MAP_API = MAP_API_KEY;
+ export const f = firebase;
+ export const database = firebase.database();
+ export const auth = firebase.auth();
+ export const storage = firebase.storage();
+ export const MAP_API = MAP_API_KEY;

--- a/config/config.example.js
+++ b/config/config.example.js
@@ -6,14 +6,14 @@ var config = {
   databaseURL: "",
   projectId: "",
   storageBucket: "",
-  messagingSenderId: ""
-  };
-  firebase.initializeApp(config);
+  messagingSenderId: "",
+};
+!firebase.apps.length ? firebase.initializeApp(config) : firebase.app();
 
-  var MAP_API_KEY = "";
+var MAP_API_KEY = "";
 
-  export const f = firebase;
-  export const database = firebase.database();
-  export const auth = firebase.auth();
-  export const storage = firebase.storage();
-  export const MAP_API = MAP_API_KEY;
+export const f = firebase;
+export const database = firebase.database();
+export const auth = firebase.auth();
+export const storage = firebase.storage();
+export const MAP_API = MAP_API_KEY;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "email-validator": "^2.0.4",
-    "firebase": "^7.2.2",
+    "firebase": "^8.6.7",
     "react": "16.12.0",
     "react-native": "^0.58.6",
     "react-native-elements": "^1.1.0",


### PR DESCRIPTION
While running the app we are getting `object not iterable error ` due to firebase versioning and lack of `appId` and `measurementId`  in `config` object as it is necessary to add `appId` for firebase versions >`7.2.0`


![115932068-d5e64b80-a4a9-11eb-9045-37cf4045cccc](https://user-images.githubusercontent.com/58719389/159777104-3ab52cac-96da-44da-8a33-864f7aafdc8d.jpeg)




This PR is for fixing that issue.

