### PR TITLE
fix for `java.lang.ExceptionInInitializerError`

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -21,3 +21,4 @@ android.useDeprecatedNdk=true
 
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.jvmargs=--add-opens java.base/java.lang=ALL-UNNAMED


### PR DESCRIPTION


    fix for `java.lang.ExceptionInInitializerError`

    **Resources for this fix:**

-     https://stackoverflow.com/questions/67782975/how-to-fix-the-module-java-base-does-not-opens-java-io-to-unnamed-module
