### PR TITLE
fix for `unable to load script` from assets

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
       android:name=".MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
+      android:usesCleartextTraffic="true"
       android:allowBackup="false"
       android:theme="@style/AppTheme">
       <activity


### PR DESCRIPTION
fix for  **unable to load script from assets** #138 

    Resources for this fix:
-   https://www.pdftron.com/documentation/android/faq/uses-clear-text-traffic/
-   https://stackoverflow.com/questions/44446523/unable-to-load-script-from-assets-index-android-bundle-on-windows
