### PR TITLE
`dependency fix` for @react-native-community/toolbar-android

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "jest --detectOpenHandles -u"
   },
   "dependencies": {
+    "@react-native-community/toolbar-android": "^0.2.1",
     "email-validator": "^2.0.4",
     "firebase": "^7.2.2",
     "react": "16.12.0",


### PR DESCRIPTION
fix for dependency 
    Updated **package.js** as `@react-native-community/toolbar-android` module is missing in the dependency